### PR TITLE
SNMP community column bug and typo

### DIFF
--- a/docker-cmd.sh
+++ b/docker-cmd.sh
@@ -56,7 +56,7 @@ done
 do
   GROUPHOST=`echo "$NODE" | cut -d ":" -f1`
   HOST=`echo "$GROUPHOST" | cut -d ";" -f2`
-  COMMUNITY=`echo "$NODE" | cut -d ":" -f2`
+  COMMUNITY=`echo "$NODE" | cut -d ":" -f3`
   if ! grep -q "$HOST" /etc/munin/munin-conf.d/snmp-nodes.conf 2>/dev/null ; then
     cat << EOF >> /etc/munin/munin-conf.d/snmp-nodes.conf
 [$GROUPHOST]

--- a/docker-cmd.sh
+++ b/docker-cmd.sh
@@ -51,14 +51,14 @@ EOF
   fi
 done
 
-# Generate smtp node list, and query smtp hosts for config
+# Generate snmp node list, and query snmp hosts for config
 [[ ! -z "$SNMP_NODES" ]] && for NODE in $SNMP_NODES
 do
   GROUPHOST=`echo "$NODE" | cut -d ":" -f1`
   HOST=`echo "$GROUPHOST" | cut -d ";" -f2`
   COMMUNITY=`echo "$NODE" | cut -d ":" -f2`
-  if ! grep -q "$HOST" /etc/munin/munin-conf.d/smtp-nodes.conf 2>/dev/null ; then
-    cat << EOF >> /etc/munin/munin-conf.d/smtp-nodes.conf
+  if ! grep -q "$HOST" /etc/munin/munin-conf.d/snmp-nodes.conf 2>/dev/null ; then
+    cat << EOF >> /etc/munin/munin-conf.d/snmp-nodes.conf
 [$GROUPHOST]
     address 127.0.0.1
     use_node_name no


### PR DESCRIPTION
The entrypoint script cuts column 2 of `SNMP_NODES` for SNMP community, however this is the hostname. Should use column 3 otherwise SNMP won't work.

The `SNMP` (Simple Network Management Protocol) configuration file is named as `SMTP` (Simple Mail Transfer Protocol); however, fixing this typo may result in a breaking change for existing users.